### PR TITLE
Fix TypeError in /predict/ caused by ONNX output shape change

### DIFF
--- a/chapter13/complete/main.py
+++ b/chapter13/complete/main.py
@@ -79,9 +79,6 @@ def predict(features: FantasyAcquisitionFeatures):
 
 
     # Return prediction as a Pydantic response model
-    return PredictionOutput(winning_bid_10th_percentile=round(
-                                float(pred_onx_10[0]),2),
-                            winning_bid_50th_percentile=round(
-                                float(pred_onx_50[0]),2),
-                            winning_bid_90th_percentile=round(
-                                float(pred_onx_90[0]), 2))
+    return PredictionOutput(winning_bid_10th_percentile=round(pred_onx_10.item(),2),
+                            winning_bid_50th_percentile=round(pred_onx_50.item(),2),
+                            winning_bid_90th_percentile=round(pred_onx_90.item(),2))


### PR DESCRIPTION
## Problem

`POST /predict/` returns `500 Internal Server Error`:

```
File "main.py", line 82, in predict
    return PredictionOutput(winning_bid_10th_percentile = round(float(pred_onx_10[0]),2),
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

Current versions of `skl2onnx` / `onnxruntime` export single-output regressors with shape `(1, 1)` instead of `(1,)`. So `pred_onx_10[0]` is `array([0.42])` rather than a 0-d scalar, and `float(...)` fails.

## Fix

Replace `float(arr[0])` with `arr.item()` in `main.py`. Works for both `(1,)` and `(1, 1)` outputs, and raises clearly if the array ever has more than one element.

```python
return PredictionOutput(
    winning_bid_10th_percentile = round(pred_onx_10.item(), 2),
    winning_bid_50th_percentile = round(pred_onx_50.item(), 2),
    winning_bid_90th_percentile = round(pred_onx_90.item(), 2),
)
```

## Tested

`onnxruntime==1.26.0` · `skl2onnx==1.20.0` · `scikit-learn==1.8.0`